### PR TITLE
Remove rules that are now defaults

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,16 +12,9 @@ module.exports = {
     recommended: {
       extends: 'octane',
       rules: {
-        'require-valid-alt-text': true,
         'inline-link-to': true,
-        'deprecated-each-syntax': true,
-        'deprecated-inline-view-helper': true,
         'eol-last': 'always',
-        'link-href-attributes': true,
         'no-bare-strings': true,
-        'no-extra-mut-helper-argument': true,
-        'no-implicit-this': true,
-        'no-trailing-spaces': true,
         quotes: 'double',
       }
     }


### PR DESCRIPTION
These are now in the octane set in the latest v3 of ember-template-lint